### PR TITLE
Xml search scopus

### DIFF
--- a/papery.py
+++ b/papery.py
@@ -2,6 +2,7 @@ import os
 
 KCI_PAPER_DATA_URL = 'https://open.kci.go.kr/po/openapi/openApiSearch.kci'
 SCOPUS_SCOPUS_SEARCH_URL = 'https://api.elsevier.com/content/search/scopus'
+SCOPUS_ABSTRACT_URL = 'http://api.elsevier.com/content/abstract/eid'
 KCI_KEY = os.environ['PAPER_API_KCI_KEY']
 SCOPUS_KEY = os.environ['PAPER_API_SCOPUS_KEY']
 CACHE_PREFIX = 'cache/'

--- a/papery.py
+++ b/papery.py
@@ -1,7 +1,9 @@
 import os
 
-paperDataUrl = 'https://open.kci.go.kr/po/openapi/openApiSearch.kci'
-KEY = os.environ['PAPER_API_KEY']
+KCI_PAPER_DATA_URL = 'https://open.kci.go.kr/po/openapi/openApiSearch.kci'
+SCOPUS_SCOPUS_SEARCH_URL = 'https://api.elsevier.com/content/search/scopus'
+KCI_KEY = os.environ['PAPER_API_KCI_KEY']
+SCOPUS_KEY = os.environ['PAPER_API_SCOPUS_KEY']
 CACHE_PREFIX = 'cache/'
 
 parseCnt = 100

--- a/xmlParsing.py
+++ b/xmlParsing.py
@@ -31,7 +31,16 @@ class KCIPageParser:
     def fsearch(self):
         i = 0
         while True:
-            file_path = papery.CACHE_PREFIX + 'kci/' + self.__searchStr + '.xml' + str(i)
+            if self.__searchMode == self.TITLE_MODE:
+                file_path = papery.CACHE_PREFIX + 'kci/title/' + self.__searchStr + '.xml' + str(i)
+            elif self.__searchMode == self.AUTHOR_MODE:
+                file_path = papery.CACHE_PREFIX + 'kci/author/' + self.__searchStr + '.xml' + str(i)
+            elif self.__searchMode == self.JOURNAL_MODE:
+                file_path = papery.CACHE_PREFIX + 'kci/journal/' + self.__searchStr + '.xml' + str(i)
+            elif self.__searchMode == self.INSTITUTION_MODE:
+                file_path = papery.CACHE_PREFIX + 'kci/institution/' + self.__searchStr + '.xml' + str(i)
+            else:
+                raise ValueError('Invalid search mode')
 
             if os.path.isfile(file_path):
                 self.__pages.append( open(file_path, 'r', encoding='utf-8').read() )
@@ -68,7 +77,17 @@ class KCIPageParser:
             return self.__pages
         
         for i, xml in enumerate(self.__pages):
-            path = papery.CACHE_PREFIX + 'kci/' + self.__searchStr + '.xml' + str(i)
+            if self.__searchMode == self.TITLE_MODE:
+                path = papery.CACHE_PREFIX + 'kci/title/' + self.__searchStr + '.xml' + str(i)
+            elif self.__searchMode == self.AUTHOR_MODE:
+                path = papery.CACHE_PREFIX + 'kci/author/' + self.__searchStr + '.xml' + str(i)
+            elif self.__searchMode == self.JOURNAL_MODE:
+                path = papery.CACHE_PREFIX + 'kci/journal/' + self.__searchStr + '.xml' + str(i)
+            elif self.__searchMode == self.INSTITUTION_MODE:
+                path = papery.CACHE_PREFIX + 'kci/institution/' + self.__searchStr + '.xml' + str(i)
+            else:
+                raise ValueError('Invalid search mode')
+
             with open(path, 'w', encoding='utf-8') as f:
                 f.write(xml)
 
@@ -192,7 +211,16 @@ class ScopusPageParser:
     def fsearch(self):
         i = 0
         while True:
-            file_path = papery.CACHE_PREFIX + 'scopus/' + self.__searchStr + '.xml' + str(i)
+            if self.__searchMode == self.TITLE_MODE:
+                file_path = papery.CACHE_PREFIX + 'scopus/title/' + self.__searchStr + '.xml' + str(i)
+            elif self.__searchMode == self.AUTHOR_MODE:
+                file_path = papery.CACHE_PREFIX + 'scopus/author/' + self.__searchStr + '.xml' + str(i)
+            elif self.__searchMode == self.JOURNAL_MODE:
+                file_path = papery.CACHE_PREFIX + 'scopus/journal/' + self.__searchStr + '.xml' + str(i)
+            elif self.__searchMode == self.INSTITUTION_MODE:
+                file_path = papery.CACHE_PREFIX + 'scopus/institution/' + self.__searchStr + '.xml' + str(i)
+            else:
+                raise ValueError('Invalid search mode')
 
             if os.path.isfile(file_path):
                 self.__pages.append( open(file_path, 'r', encoding='utf-8').read() )
@@ -228,7 +256,17 @@ class ScopusPageParser:
             return self.__pages
         
         for i, xml in enumerate(self.__pages):
-            path = papery.CACHE_PREFIX + 'scopus/' + self.__searchStr + '.xml' + str(i)
+            if self.__searchMode == self.TITLE_MODE:
+                path = papery.CACHE_PREFIX + 'scopus/title/' + self.__searchStr + '.xml' + str(i)
+            elif self.__searchMode == self.AUTHOR_MODE:
+                path = papery.CACHE_PREFIX + 'scopus/author/' + self.__searchStr + '.xml' + str(i)
+            elif self.__searchMode == self.JOURNAL_MODE:
+                path = papery.CACHE_PREFIX + 'scopus/journal/' + self.__searchStr + '.xml' + str(i)
+            elif self.__searchMode == self.INSTITUTION_MODE:
+                path = papery.CACHE_PREFIX + 'scopus/institution/' + self.__searchStr + '.xml' + str(i)
+            else:
+                raise ValueError('Invalid search mode')
+            
             with open(path, 'w', encoding='utf-8') as f:
                 f.write(xml)
 
@@ -361,7 +399,7 @@ class KCIDetailParser:
         if not willCache:
             return self.__detail
         
-        with open(papery.CACHE_PREFIX + 'kci/' + self.__articleID + '.xml', 'w', encoding='utf-8') as f:
+        with open(papery.CACHE_PREFIX + 'kci/detail/' + self.__articleID + '.xml', 'w', encoding='utf-8') as f:
             f.write(self.__detail)
 
         return self.__detail
@@ -370,7 +408,7 @@ class KCIDetailParser:
     # expect the file to be named as #.xml
     # where # is the article ID
     def fsearch(self):
-        file_path = papery.CACHE_PREFIX + 'kci/' + self.__articleID + '.xml'
+        file_path = papery.CACHE_PREFIX + 'kci/detail/' + self.__articleID + '.xml'
 
         if os.path.isfile(file_path):
             self.__detail = open(file_path, 'r', encoding='utf-8').read()

--- a/xmlParsing.py
+++ b/xmlParsing.py
@@ -6,7 +6,7 @@ import os
 
 class PageParser:
     KCI = 'KCI'
-    GOOGLE_SCHOLAR = 'Google Scholar'
+    SCOPUS = 'Scopus'
     TITLE_MODE = 0
     AUTHOR_MODE = 1
     JOURNAL_MODE = 2
@@ -56,14 +56,14 @@ class PageParser:
 
         return self.__pages
     
-    def __isearchGoogleScholar(self, willCache=True):
+    def __isearchScopus(self, willCache=True):
         pass
 
     def isearch(self, willCache=True):
         if self.__source == self.KCI:
             return self.__isearchKCI(willCache)
-        elif self.__source == self.GOOGLE_SCHOLAR:
-            return self.__isearchGoogleScholar(willCache)
+        elif self.__source == self.SCOPUS:
+            return self.__isearchScopus(willCache)
         raise ValueError('Invalid source')
 
     # short for file search
@@ -212,7 +212,7 @@ class PageParseResult:
 
 class DetailParser:
     KCI = 'KCI'
-    GOOGLE_SCHOLAR = 'Google Scholar'
+    SCOPUS = 'Scopus'
 
     def __init__(self, articleID, source=KCI):
         self.__key = papery.KEY
@@ -236,14 +236,14 @@ class DetailParser:
 
         return self.__detail
     
-    def __isearchGoogleScholar(self, willCache=True):
+    def __isearchScopus(self, willCache=True):
         pass
 
     def isearch(self, willCache=True):
         if self.__source == self.KCI:
             return self.__isearchKCI(willCache)
-        elif self.__source == self.GOOGLE_SCHOLAR:
-            return self.__isearchGoogleScholar(willCache)
+        elif self.__source == self.SCOPUS:
+            return self.__isearchScopus(willCache)
         raise ValueError('Invalid source')
     
     # short for file search

--- a/xmlParsing.py
+++ b/xmlParsing.py
@@ -120,7 +120,7 @@ class KCIPageParser:
                 jour = item.find('journalInfo')
                 arti = item.find('articleInfo')
 
-                self.results.append( PageParseResult(
+                self.results.append( KCIPageParseResult(
                     self.__getArticleID(arti),
                     self.__getTitle(arti),
                     self.__getAuthorNames(arti),
@@ -291,20 +291,17 @@ class ScopusPageParser:
             root = ET.fromstring(page)
 
             for item in root.findall('atom:entry', ScopusPageParser.XML_NAMESPACES):
-                self.results.append( PageParseResult(
+                self.results.append( ScopusPageParseResult(
                     articleID=self.__getArticleID(item),
                     title=self.__getTitle(item),
                     authors=self.__getAuthorNames(item),
                     year=self.__getPubYear(item),
-                    abstract=None,
-                    # self.__getAbstract(item),
                     journal=self.__getJournal(item),
                     institution=self.__getInstitution(item),
                     volume=self.__getVolume(item),
                     issue=self.__getIssue(item),
                     doi=self.__getDOI(item),
                     url=None,
-                    # self.__getURL(item),
                     citationCnt=self.__getCitationCount(item)
                 ) )
 
@@ -435,7 +432,7 @@ class PageParser:
             return None
         raise ValueError('Invalid source')
     
-class PageParseResult:
+class KCIPageParseResult:
     def __init__(self, articleID, title, authors,
         year, abstract ,journal, institution,
         volume, issue, doi, url, citationCnt
@@ -464,6 +461,34 @@ class PageParseResult:
         paper.issue = self.issue
         paper.doi = self.doi
         paper.url = self.url
+        paper.citationCnt = self.citationCnt
+        paper.articleID = self.articleID
+
+class ScopusPageParseResult:
+    def __init__(self, articleID, title, authors,
+        year, journal, institution,
+        volume, issue, doi, citationCnt
+    ):
+        self.articleID = articleID
+        self.title = title
+        self.authors = authors
+        self.year = year
+        self.journal = journal
+        self.institution = institution
+        self.volume = volume
+        self.issue = issue
+        self.doi = doi
+        self.citationCnt = citationCnt
+
+    def reflect(self, paper):
+        paper.title = self.title
+        paper.authors = self.authors
+        paper.year = self.year
+        paper.journal = self.journal
+        paper.institution = self.institution
+        paper.volume = self.volume
+        paper.issue = self.issue
+        paper.doi = self.doi
         paper.citationCnt = self.citationCnt
         paper.articleID = self.articleID
 
@@ -521,7 +546,7 @@ class KCIDetailParser:
             keywords.extend( self.__getKeywords(arti) )
             authorInsts.extend( self.__getAuthorInsts(arti) )
 
-        return DetailParseResult(keywords, refs, authorInsts)
+        return KCIDetailParseResult(keywords, refs, authorInsts)
 
     def isearchAndParse(self, willCache=True):
         self.isearch(willCache)
@@ -624,13 +649,26 @@ class DetailParser:
             return None
         raise ValueError('Invalid source')
     
-class DetailParseResult:
+class KCIDetailParseResult:
     def __init__(self, keywords, refs, authorInsts):
         self.keywords = keywords
         self.refs = refs
         self.authorInsts = authorInsts
 
     def reflect(self, paper):
+        paper.keywords = self.keywords
+        paper.refs = self.refs
+        paper.authorInsts = self.authorInsts
+
+class ScopusDetailParseResult:
+    def __init__(self, abstract, keywords, refs, authorInsts):
+        self.abstract = abstract
+        self.keywords = keywords
+        self.refs = refs
+        self.authorInsts = authorInsts
+
+    def reflect(self, paper):
+        paper.abstract = self.abstract
         paper.keywords = self.keywords
         paper.refs = self.refs
         paper.authorInsts = self.authorInsts


### PR DESCRIPTION
## 구현된 기능
- Scopus를 통한 해외 논문 검색, 다음의 정보를 돌려줌
  - 제목
  - 저자
  - 발행연도
  - 학술지
  - 기관
  - 권
  - 호
  - 피인용수
  - 논문ID
  - doi
- 다양한 검색 모드 백엔드 지원
  - `PageParser::TITLE_MODE`: 제목 검색
  - `PageParser::AUTHOR_MODE`: 저자 검색
  - `PageParser::JOURNAL_MODE`: 학술지 검색
  - `PageParser::INSTITUTION_MODE`: 기관 검색

## Note
- Scopus 검색 구현으로 인해 기존의 `PageParser`, `DetailParser`는 가상화된 클래스가 되고,
  그것의 구현이 `KCIPageParser`, `ScopusPageParser`, `KCIDetailParser`, `ScopusDetailParser`를 통해 이루어지게 됨
- 다음의 디렉터리들이 존재해야 프로그램을 실행시킬 수 있음
  - `cache/kci/title`
  - `cache/kci/author`
  - `cache/kci/journal`
  - `cache/kci/institution`
  - `cache/kci/detail`
  - `cache/scopus/title`
  - `cache/scopus/author`
  - `cache/scopus/journal`
  - `cache/scopus/institution`
  - `cache/scopus/abstract`