### PR TITLE
Xml search 중간 Merge

### DIFF
--- a/GuiConfig.py
+++ b/GuiConfig.py
@@ -3,21 +3,23 @@ from tkinter import font
 #Common
 WIDTH = 800
 HEIGHT = 600
-GIF_WIDTH = 150
-GIF_HEIGHT = 75
+GIF_WIDTH = 60
+GIF_HEIGHT = 30
 GIF_PADDINGX = 20
 GIF_PADDINGY = 10
 TABS_PADDINGX = 20
-TABS_PADDINGY = 10
+TABS_PADDINGY = 30
 WIDGET_INTERVALX = 15
 WIDGET_INTERVALY = 15
 
 #SearchTab
 SEARCH_BAR_PADDING_Y = 15
+SEARCH_MODE_TRAY_WIDTH = 200
 SEARCH_RESULT_WIDTH = 600
 SEARCH_RESULT_HEIGHT = 400
 SEARCH_RESULT_TRAY_WIDTH = 400
 SEARCH_RESULT_TRAY_HEIGHT = 30
+SEARCH_RESULT_TRAY_PADDINGY = 6
 SEARCH_ENTRY_WIDTH = 300
 SEARCH_ENTRY_HEIGHT = 25
 SEARCH_BUTTON_WIDTH = 60
@@ -38,6 +40,7 @@ paperTitleFont = None
 headFont = None
 memoFont = None
 refFont = None
+searchModeFont = None
 
 def initFonts():
     global cFont
@@ -54,3 +57,6 @@ def initFonts():
 
     global refFont
     refFont = font.Font(family="맑은 고딕", size=8, weight="normal", slant="roman")
+
+    global searchModeFont
+    searchModeFont = font.Font(family="맑은 고딕", size=8, weight="normal", slant="roman")

--- a/Loading.py
+++ b/Loading.py
@@ -1,7 +1,12 @@
 from tkinter import *
 from threading import Thread, Semaphore
+from GIFAnimation import *
+import GuiConfig
 
 class Loading:
+    def initGif():
+        Loading.gif = GIFAnimation(364, 248)
+
     def __init__(self, master, task, callback):
         self.master = master
         self.callback = callback
@@ -17,8 +22,29 @@ class Loading:
     def __initWindow(self):
         self.window = Toplevel(self.master)
         self.window.title("Loading")
-        self.label = Label(self.window, text="Loading...")
-        self.label.pack()
+        
+        self.gif = Loading.gif
+        self.gifLabel = Label(self.window, image=self.gif.image())
+        self.gifLabel.pack(padx=20)
+        self.window.after(100, self.update)
+
+        self.txtLoading = StringVar()
+        self.txtLoading.set("Loading")
+        self.txtLabel = Label(self.window, textvariable=self.txtLoading,
+            font=GuiConfig.cFont
+        )
+        self.txtLabel.pack(pady=20)
+        self.txtFrame = 0
+
+    def update(self):
+        self.gif.advance()
+        self.gifLabel.configure(image=self.gif.image())
+
+        self.txtFrame = (self.txtFrame + 1) % 20
+        txtDotCnt = self.txtFrame // 5
+        self.txtLoading.set("Loading" + "." * txtDotCnt)
+
+        self.window.after(100, self.update)
 
     def __runTask(self, task):
         self.result = task()

--- a/Loading.py
+++ b/Loading.py
@@ -1,0 +1,61 @@
+from tkinter import *
+from threading import Thread, Semaphore
+
+class Loading:
+    def __init__(self, master, task, callback):
+        self.master = master
+        self.callback = callback
+        self.sem = Semaphore(0)  # Initialize with 0 to block
+        self.result = None
+        self.taskThread = Thread(target=self.__runTask, args=(task,))
+        self.taskThread.start()
+        self.elapsedMs = 0
+
+        self.window = None
+        self.master.after(15, self.__checkDone)  # Start periodic check
+
+    def __initWindow(self):
+        self.window = Toplevel(self.master)
+        self.window.title("Loading")
+        self.label = Label(self.window, text="Loading...")
+        self.label.pack()
+
+    def __runTask(self, task):
+        self.result = task()
+        self.sem.release()
+
+    def __checkDone(self):
+        self.elapsedMs += 15
+        if self.sem.acquire(blocking=False):
+            if self.window is not None:
+                self.window.destroy()
+            self.callback(self.result)  # 작업 완료 후 콜백 호출
+        else:
+            if self.window is None and self.elapsedMs >= 150:
+                self.__initWindow()
+            self.master.after(15, self.__checkDone)
+
+# Test task
+def test_task():
+    import time
+    time.sleep(3)
+    return "Task completed"
+
+# Task completion callback
+def on_task_complete(result):
+    print('Task result:', result)
+    label.config(text=f"Result: {result}")
+
+
+if __name__ == "__main__":
+    # Test Tkinter window
+    root = Tk()
+    root.title("Main Window")
+
+    label = Label(root, text="Click the button to start the task")
+    label.pack(pady=20)
+
+    button = Button(root, text="Start Task", command=lambda: Loading(root, test_task, on_task_complete))
+    button.pack(pady=20)
+
+    root.mainloop()

--- a/SearchTab.py
+++ b/SearchTab.py
@@ -153,10 +153,11 @@ class SearchTab:
         self.update()
 
     def nextPage(self):
-        if self.board.pageNum % Board.PAGE_CNT_IN_A_TRAY == 0:
+        if not self.board.nextPage():
+            return
+        
+        if (self.board.pageNum - 1) % Board.PAGE_CNT_IN_A_TRAY == 0:
             self.trayBasePage += Board.PAGE_CNT_IN_A_TRAY
-
-        self.board.nextPage()
         self.update()
 
     def prevPage(self):

--- a/SearchTab.py
+++ b/SearchTab.py
@@ -122,7 +122,9 @@ class SearchTab:
 
         self.curRecords = []
 
-        for i in range(min(Board.RECORD_CNT_IN_A_PAGE, self.board.length())):
+        for i in range( min( Board.RECORD_CNT_IN_A_PAGE,
+            self.board.length() - (self.board.curPage() - 1) * Board.RECORD_CNT_IN_A_PAGE
+        ) ):
             self.curRecords.append(
                 Record(self.board.get(i), self.resultList)
             )

--- a/SearchTab.py
+++ b/SearchTab.py
@@ -105,6 +105,7 @@ class SearchTab:
         def task():
             self.onLoadingPages()
             self.board.search(self.searchStr.get(), self.searchModeIdx.get())
+            self.trayBasePage = 1
 
         def onCompletion(result):
             self.onLoadedPages()
@@ -146,6 +147,9 @@ class SearchTab:
             self.pageTrayButtons[i].grid(row=0, column=i+1)
             self.pageTray.grid_columnconfigure(i+1, weight=1)
         self.pageTray.grid_rowconfigure(0, weight=1)
+
+        for i in range(trayLen, Board.PAGE_CNT_IN_A_TRAY):
+            self.pageTrayButtons[i] = None
 
         Button( self.pageTray, text=">", font=GuiConfig.cFont,
             command=self.nextPage

--- a/SearchTab.py
+++ b/SearchTab.py
@@ -21,8 +21,8 @@ class SearchTab:
 
     def initWidgets(self):
         self.searchBar = Frame(self.frame)
-        self.searchBar.place( x=GuiConfig.TABS_PADDINGX, y=GuiConfig.SEARCH_BAR_PADDING_Y,
-            width=GuiConfig.SEARCH_ENTRY_WIDTH + GuiConfig.SEARCH_BUTTON_WIDTH + GuiConfig.WIDGET_INTERVALX,
+        self.searchBar.place( x=GuiConfig.TABS_PADDINGX * 2, y=GuiConfig.SEARCH_BAR_PADDING_Y,
+            width=GuiConfig.SEARCH_ENTRY_WIDTH + GuiConfig.SEARCH_BUTTON_WIDTH + GuiConfig.WIDGET_INTERVALX * 2 + GuiConfig.SEARCH_MODE_TRAY_WIDTH,
             height=max(GuiConfig.SEARCH_ENTRY_HEIGHT, GuiConfig.SEARCH_BUTTON_HEIGHT) + GuiConfig.WIDGET_INTERVALY,
             anchor=NW
         )
@@ -30,16 +30,43 @@ class SearchTab:
         self.searchStr = StringVar()
         self.searchStr.set("검색어를 입력하세요")
         self.entry = Entry(self.searchBar, textvariable=self.searchStr, font=GuiConfig.cFont)
-        self.entry.place( x=GuiConfig.TABS_PADDINGX, y=0,
-            width=GuiConfig.SEARCH_ENTRY_WIDTH, height=GuiConfig.SEARCH_ENTRY_HEIGHT,
-            anchor=NW
+        self.entry.place( x=0, y=0, width=GuiConfig.SEARCH_ENTRY_WIDTH,
+            height=GuiConfig.SEARCH_ENTRY_HEIGHT, anchor=NW
         )
 
-        self.button = Button(self.searchBar, text="검색", font=GuiConfig.cFont, command=self.search)
-        self.button.place( x=GuiConfig.SEARCH_ENTRY_WIDTH + GuiConfig.WIDGET_INTERVALX,
+        self.searchButton = Button(self.searchBar, text="검색", font=GuiConfig.cFont, command=self.search)
+        self.searchButton.place( x=GuiConfig.SEARCH_ENTRY_WIDTH + GuiConfig.WIDGET_INTERVALX * 2 + GuiConfig.SEARCH_MODE_TRAY_WIDTH,
             y=0, width=GuiConfig.SEARCH_BUTTON_WIDTH, height=GuiConfig.SEARCH_BUTTON_HEIGHT,
             anchor=NW
         )
+
+        self.searchModeTray = Frame(self.searchBar)
+        self.searchModeTray.place( x=GuiConfig.SEARCH_ENTRY_WIDTH + GuiConfig.WIDGET_INTERVALX,
+            y=0, width=GuiConfig.SEARCH_MODE_TRAY_WIDTH, height=GuiConfig.SEARCH_ENTRY_HEIGHT,
+            anchor=NW
+        )
+
+        self.searchModeIdx = IntVar()
+
+        self.smTitle = Radiobutton(self.searchModeTray, text="제목", font=GuiConfig.searchModeFont,
+            variable=self.searchModeIdx, value=Board.SEARCH_MODE_TITLE
+        )
+        self.smTitle.pack(side=LEFT)
+
+        self.smAuthor = Radiobutton(self.searchModeTray, text="저자", font=GuiConfig.searchModeFont,
+            variable=self.searchModeIdx, value=Board.SEARCH_MODE_AUTHOR
+        )
+        self.smAuthor.pack(side=LEFT)
+
+        self.smJournal = Radiobutton(self.searchModeTray, text="학술지", font=GuiConfig.searchModeFont,
+            variable=self.searchModeIdx, value=Board.SEARCH_MODE_JOURNAL
+        )
+        self.smJournal.pack(side=LEFT)
+
+        self.smInstitution = Radiobutton(self.searchModeTray, text="기관", font=GuiConfig.searchModeFont,
+            variable=self.searchModeIdx, value=Board.SEARCH_MODE_INSTITUTION
+        )
+        self.smInstitution.pack(side=LEFT)
 
         self.result = Frame(self.frame, height=GuiConfig.SEARCH_RESULT_HEIGHT)
         self.result.place( x=GuiConfig.TABS_PADDINGX,
@@ -58,7 +85,7 @@ class SearchTab:
 
         self.pageTray = Frame(self.result)
         self.pageTray.place( x=(GuiConfig.SEARCH_RESULT_WIDTH - GuiConfig.SEARCH_RESULT_TRAY_WIDTH) // 2,
-            y=GuiConfig.SEARCH_RESULT_HEIGHT + GuiConfig.WIDGET_INTERVALY,
+            y=GuiConfig.SEARCH_RESULT_HEIGHT + GuiConfig.SEARCH_RESULT_TRAY_PADDINGY,
             width=GuiConfig.SEARCH_RESULT_TRAY_WIDTH,
             height=GuiConfig.SEARCH_RESULT_TRAY_HEIGHT,
             anchor=NW
@@ -73,11 +100,7 @@ class SearchTab:
         )
 
     def search(self):
-        self.board.search(self.searchStr.get())
-
-        # temporary implementation
-        # self.board.loadCache(self.searchStr.get())
-
+        self.board.search(self.searchStr.get(), self.searchModeIdx.get())
         self.update()
 
     def update(self):

--- a/SearchTab.py
+++ b/SearchTab.py
@@ -97,7 +97,7 @@ class SearchTab:
             self.resultList.grid_rowconfigure(i, weight=1)
         self.resultList.grid_columnconfigure(0, weight=1)
 
-        trayLen = min( self.board.length() // Board.RECORD_CNT_IN_A_PAGE,
+        trayLen = min( self.board.length() // Board.RECORD_CNT_IN_A_PAGE + 1,
             Board.PAGE_CNT_IN_A_TRAY
         )
 

--- a/board.py
+++ b/board.py
@@ -23,6 +23,7 @@ class Board:
         self.searchMode = Board.SEARCH_MODE_TITLE
 
     def search(self, searchStr, searchMode=SEARCH_MODE_TITLE):
+        self.papers = []
         self.searchRange(searchStr, searchMode, 0,
             Board.PAGE_CNT_IN_A_SEARCH * Board.RECORD_CNT_IN_A_PAGE - 1
         )
@@ -34,8 +35,6 @@ class Board:
     # [start, end] is an 0-based inclusive range of indices
     # remote page referes to the XML's page
     def searchRange(self, searchStr, searchMode, start, end):
-        if self.searchStr != searchStr or self.searchMode != searchMode:
-            self.papers = []
         self.searchStr = searchStr
         self.searchMode = searchMode
 

--- a/board.py
+++ b/board.py
@@ -26,6 +26,7 @@ class Board:
         self.searchRange(searchStr, searchMode, 0,
             Board.PAGE_CNT_IN_A_SEARCH * Board.RECORD_CNT_IN_A_PAGE - 1
         )
+        self.pageNum = 1
 
     def length(self):
         return len(self.papers)

--- a/board.py
+++ b/board.py
@@ -3,6 +3,7 @@ from xmlParsing import PageParser
 import papery
 
 from tkinter import *
+from tkinter import messagebox
 import GuiConfig
 
 class Board:
@@ -51,8 +52,6 @@ class Board:
             Board.SEARCH_UNIT * (remotePageEnd - remotePageStart + 1)
         ).searchAndParse()
 
-        self.papers = []
-
         for parseResult in parseResults:
             self.papers.append( Paper() )
             parseResult.reflect(self.papers[-1])
@@ -66,6 +65,10 @@ class Board:
                 (self.pageNum + Board.PAGE_CNT_IN_A_SEARCH) * Board.RECORD_CNT_IN_A_PAGE - 1
             )
 
+        if self.length() <= self.pageNum * Board.RECORD_CNT_IN_A_PAGE:
+            messagebox.showinfo('알림', '마지막 페이지입니다.')
+            return
+
         self.pageNum += 1
 
     def prevPage(self):
@@ -73,16 +76,11 @@ class Board:
         if self.pageNum < 1:
             self.pageNum = 1
 
-        if self.pageNum % Board.PAGE_CNT_IN_A_SEARCH == 0:
-            self.searchRange(self.searchStr, (self.pageNum - Board.PAGE_CNT_IN_A_SEARCH) * Board.RECORD_CNT_IN_A_PAGE,
-                self.pageNum * Board.RECORD_CNT_IN_A_PAGE - 1
-            )
-
     def get(self, index):
         if not (0 <= index < Board.RECORD_CNT_IN_A_PAGE):
             raise ValueError('index out of range')
 
-        return self.papers[ ((self.pageNum-1) % Board.PAGE_CNT_IN_A_SEARCH) * Board.RECORD_CNT_IN_A_PAGE + index ]
+        return self.papers[ (self.pageNum-1) * Board.RECORD_CNT_IN_A_PAGE + index ]
 
 class Record:
     def __init__(self, paper, master):

--- a/board.py
+++ b/board.py
@@ -33,6 +33,8 @@ class Board:
     # [start, end] is an 0-based inclusive range of indices
     # remote page referes to the XML's page
     def searchRange(self, searchStr, searchMode, start, end):
+        if self.searchStr != searchStr or self.searchMode != searchMode:
+            self.papers = []
         self.searchStr = searchStr
         self.searchMode = searchMode
 

--- a/board.py
+++ b/board.py
@@ -10,45 +10,44 @@ class Board:
     PAGE_CNT_IN_A_SEARCH = 30
     RECORD_CNT_IN_A_PAGE = 10
     SEARCH_UNIT = 100   # must be a multiple of 100
+    SEARCH_MODE_TITLE = 0
+    SEARCH_MODE_AUTHOR = 1
+    SEARCH_MODE_JOURNAL = 2
+    SEARCH_MODE_INSTITUTION = 3
 
     def __init__(self):
         self.papers = []
         self.pageNum = 1
         self.searchStr = ''
 
-    # replace commented code with newer practical code
-    def loadCache(self, searchStr):
-        # if searchStr == '컴퓨터':
-        #     parser = xmlParsing(papery.KEY, "컴퓨터", papery.paperDataUrl,
-        #         1, Board.SEARCH_UNIT * 3
-        #     )
-        #     parser.parseFromXMLFile('computer.xml')
-        #     self.searchStr = "컴퓨터"
-        # elif searchStr == '게임':
-        #     parser = xmlParsing(papery.KEY, "게임", papery.paperDataUrl,
-        #         1, Board.SEARCH_UNIT * 3
-        #     )
-        #     parser.parseFromXMLFile('game.xml')
-        #     self.searchStr = "게임"
-
-        # self.papers = parser.papers[:]
-        pass
-
-    def search(self, searchStr):
-        self.searchRange(searchStr, 0, Board.PAGE_CNT_IN_A_SEARCH * Board.RECORD_CNT_IN_A_PAGE - 1)
+    def search(self, searchStr, searchMode=SEARCH_MODE_TITLE):
+        self.searchRange(searchStr, searchMode, 0,
+            Board.PAGE_CNT_IN_A_SEARCH * Board.RECORD_CNT_IN_A_PAGE - 1
+        )
 
     def length(self):
         return len(self.papers)
 
     # [start, end] is an 0-based inclusive range of indices
     # remote page referes to the XML's page
-    def searchRange(self, searchStr, start, end):
+    def searchRange(self, searchStr, searchMode, start, end):
         self.searchStr = searchStr
 
         remotePageStart = start // Board.SEARCH_UNIT + 1
         remotePageEnd = end // Board.SEARCH_UNIT + 1
 
-        parseResults = PageParser( searchStr, PageParser.TITLE_MODE, remotePageStart,
+        if searchMode == Board.SEARCH_MODE_TITLE:
+            searchMode = PageParser.TITLE_MODE
+        elif searchMode == Board.SEARCH_MODE_AUTHOR:
+            searchMode = PageParser.AUTHOR_MODE
+        elif searchMode == Board.SEARCH_MODE_JOURNAL:
+            searchMode = PageParser.JOURNAL_MODE
+        elif searchMode == Board.SEARCH_MODE_INSTITUTION:
+            searchMode = PageParser.INSTITUTION_MODE
+        else:
+            raise ValueError('invalid search mode')
+
+        parseResults = PageParser( searchStr, searchMode, remotePageStart,
             Board.SEARCH_UNIT * (remotePageEnd - remotePageStart + 1)
         ).searchAndParse()
 

--- a/board.py
+++ b/board.py
@@ -20,6 +20,7 @@ class Board:
         self.papers = []
         self.pageNum = 1
         self.searchStr = ''
+        self.searchMode = Board.SEARCH_MODE_TITLE
 
     def search(self, searchStr, searchMode=SEARCH_MODE_TITLE):
         self.searchRange(searchStr, searchMode, 0,
@@ -33,6 +34,7 @@ class Board:
     # remote page referes to the XML's page
     def searchRange(self, searchStr, searchMode, start, end):
         self.searchStr = searchStr
+        self.searchMode = searchMode
 
         remotePageStart = start // Board.SEARCH_UNIT + 1
         remotePageEnd = end // Board.SEARCH_UNIT + 1
@@ -61,15 +63,16 @@ class Board:
 
     def nextPage(self):
         if self.pageNum % Board.PAGE_CNT_IN_A_SEARCH == 0:
-            self.searchRange(self.searchStr, self.pageNum * Board.RECORD_CNT_IN_A_PAGE,
+            self.searchRange(self.searchStr, self.searchMode, self.pageNum * Board.RECORD_CNT_IN_A_PAGE,
                 (self.pageNum + Board.PAGE_CNT_IN_A_SEARCH) * Board.RECORD_CNT_IN_A_PAGE - 1
             )
 
         if self.length() <= self.pageNum * Board.RECORD_CNT_IN_A_PAGE:
             messagebox.showinfo('알림', '마지막 페이지입니다.')
-            return
+            return False
 
         self.pageNum += 1
+        return True
 
     def prevPage(self):
         self.pageNum -= 1

--- a/board.py
+++ b/board.py
@@ -81,6 +81,9 @@ class Board:
         if self.pageNum < 1:
             self.pageNum = 1
 
+    def curPage(self):
+        return self.pageNum
+
     def get(self, index):
         if not (0 <= index < Board.RECORD_CNT_IN_A_PAGE):
             raise ValueError('index out of range')

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from LogTab import *
 from ViewTab import *
 
 from GIFAnimation import *
+from Loading import Loading
 import GuiConfig
 
 class MainGUI:
@@ -45,6 +46,7 @@ class MainGUI:
             x=GuiConfig.WIDTH - GuiConfig.GIF_PADDINGX, y=GuiConfig.GIF_PADDINGY,
             anchor=NE, width=GuiConfig.GIF_WIDTH, height=GuiConfig.GIF_HEIGHT
         )
+        Loading.initGif()
 
         self.defaultbg = self.master.cget('bg')
 

--- a/paper.py
+++ b/paper.py
@@ -1,8 +1,9 @@
 class Paper:
     def __init__( self, title = None, authors = None, year = None,
         authorInsts = None, journal = None, volume = None, issue = None,
-        doi = None, url = None, abstract = None, citationCnt = None,
-        keywords = None, refs = None, institution = None, articleID = None
+        fPage = None, lPage = None, doi = None, url = None, abstract = None,
+        citationCnt = None, keywords = None, refs = None, institution = None,
+        articleID = None
     ):
         self.title = title
         self.authors = authors
@@ -11,6 +12,8 @@ class Paper:
         self.journal = journal
         self.volume = volume
         self.issue = issue
+        self.fPage = fPage
+        self.lPage = lPage
         self.doi = doi
         self.url = url
         self.abstract = abstract

--- a/papery.py
+++ b/papery.py
@@ -2,6 +2,7 @@ import os
 
 KCI_PAPER_DATA_URL = 'https://open.kci.go.kr/po/openapi/openApiSearch.kci'
 SCOPUS_SCOPUS_SEARCH_URL = 'https://api.elsevier.com/content/search/scopus'
+SCOPUS_ABSTRACT_URL = 'http://api.elsevier.com/content/abstract/eid'
 KCI_KEY = os.environ['PAPER_API_KCI_KEY']
 SCOPUS_KEY = os.environ['PAPER_API_SCOPUS_KEY']
 CACHE_PREFIX = 'cache/'

--- a/papery.py
+++ b/papery.py
@@ -1,7 +1,9 @@
 import os
 
-paperDataUrl = 'https://open.kci.go.kr/po/openapi/openApiSearch.kci'
-KEY = os.environ['PAPER_API_KEY']
+KCI_PAPER_DATA_URL = 'https://open.kci.go.kr/po/openapi/openApiSearch.kci'
+SCOPUS_SCOPUS_SEARCH_URL = 'https://api.elsevier.com/content/search/scopus'
+KCI_KEY = os.environ['PAPER_API_KCI_KEY']
+SCOPUS_KEY = os.environ['PAPER_API_SCOPUS_KEY']
 CACHE_PREFIX = 'cache/'
 
 parseCnt = 100

--- a/xmlParsing.py
+++ b/xmlParsing.py
@@ -31,7 +31,16 @@ class KCIPageParser:
     def fsearch(self):
         i = 0
         while True:
-            file_path = papery.CACHE_PREFIX + 'kci/' + self.__searchStr + '.xml' + str(i)
+            if self.__searchMode == self.TITLE_MODE:
+                file_path = papery.CACHE_PREFIX + 'kci/title/' + self.__searchStr + '.xml' + str(i)
+            elif self.__searchMode == self.AUTHOR_MODE:
+                file_path = papery.CACHE_PREFIX + 'kci/author/' + self.__searchStr + '.xml' + str(i)
+            elif self.__searchMode == self.JOURNAL_MODE:
+                file_path = papery.CACHE_PREFIX + 'kci/journal/' + self.__searchStr + '.xml' + str(i)
+            elif self.__searchMode == self.INSTITUTION_MODE:
+                file_path = papery.CACHE_PREFIX + 'kci/institution/' + self.__searchStr + '.xml' + str(i)
+            else:
+                raise ValueError('Invalid search mode')
 
             if os.path.isfile(file_path):
                 self.__pages.append( open(file_path, 'r', encoding='utf-8').read() )
@@ -68,7 +77,17 @@ class KCIPageParser:
             return self.__pages
         
         for i, xml in enumerate(self.__pages):
-            path = papery.CACHE_PREFIX + 'kci/' + self.__searchStr + '.xml' + str(i)
+            if self.__searchMode == self.TITLE_MODE:
+                path = papery.CACHE_PREFIX + 'kci/title/' + self.__searchStr + '.xml' + str(i)
+            elif self.__searchMode == self.AUTHOR_MODE:
+                path = papery.CACHE_PREFIX + 'kci/author/' + self.__searchStr + '.xml' + str(i)
+            elif self.__searchMode == self.JOURNAL_MODE:
+                path = papery.CACHE_PREFIX + 'kci/journal/' + self.__searchStr + '.xml' + str(i)
+            elif self.__searchMode == self.INSTITUTION_MODE:
+                path = papery.CACHE_PREFIX + 'kci/institution/' + self.__searchStr + '.xml' + str(i)
+            else:
+                raise ValueError('Invalid search mode')
+
             with open(path, 'w', encoding='utf-8') as f:
                 f.write(xml)
 
@@ -192,7 +211,16 @@ class ScopusPageParser:
     def fsearch(self):
         i = 0
         while True:
-            file_path = papery.CACHE_PREFIX + 'scopus/' + self.__searchStr + '.xml' + str(i)
+            if self.__searchMode == self.TITLE_MODE:
+                file_path = papery.CACHE_PREFIX + 'scopus/title/' + self.__searchStr + '.xml' + str(i)
+            elif self.__searchMode == self.AUTHOR_MODE:
+                file_path = papery.CACHE_PREFIX + 'scopus/author/' + self.__searchStr + '.xml' + str(i)
+            elif self.__searchMode == self.JOURNAL_MODE:
+                file_path = papery.CACHE_PREFIX + 'scopus/journal/' + self.__searchStr + '.xml' + str(i)
+            elif self.__searchMode == self.INSTITUTION_MODE:
+                file_path = papery.CACHE_PREFIX + 'scopus/institution/' + self.__searchStr + '.xml' + str(i)
+            else:
+                raise ValueError('Invalid search mode')
 
             if os.path.isfile(file_path):
                 self.__pages.append( open(file_path, 'r', encoding='utf-8').read() )
@@ -228,7 +256,17 @@ class ScopusPageParser:
             return self.__pages
         
         for i, xml in enumerate(self.__pages):
-            path = papery.CACHE_PREFIX + 'scopus/' + self.__searchStr + '.xml' + str(i)
+            if self.__searchMode == self.TITLE_MODE:
+                path = papery.CACHE_PREFIX + 'scopus/title/' + self.__searchStr + '.xml' + str(i)
+            elif self.__searchMode == self.AUTHOR_MODE:
+                path = papery.CACHE_PREFIX + 'scopus/author/' + self.__searchStr + '.xml' + str(i)
+            elif self.__searchMode == self.JOURNAL_MODE:
+                path = papery.CACHE_PREFIX + 'scopus/journal/' + self.__searchStr + '.xml' + str(i)
+            elif self.__searchMode == self.INSTITUTION_MODE:
+                path = papery.CACHE_PREFIX + 'scopus/institution/' + self.__searchStr + '.xml' + str(i)
+            else:
+                raise ValueError('Invalid search mode')
+            
             with open(path, 'w', encoding='utf-8') as f:
                 f.write(xml)
 
@@ -361,7 +399,7 @@ class KCIDetailParser:
         if not willCache:
             return self.__detail
         
-        with open(papery.CACHE_PREFIX + 'kci/' + self.__articleID + '.xml', 'w', encoding='utf-8') as f:
+        with open(papery.CACHE_PREFIX + 'kci/detail/' + self.__articleID + '.xml', 'w', encoding='utf-8') as f:
             f.write(self.__detail)
 
         return self.__detail
@@ -370,7 +408,7 @@ class KCIDetailParser:
     # expect the file to be named as #.xml
     # where # is the article ID
     def fsearch(self):
-        file_path = papery.CACHE_PREFIX + 'kci/' + self.__articleID + '.xml'
+        file_path = papery.CACHE_PREFIX + 'kci/detail/' + self.__articleID + '.xml'
 
         if os.path.isfile(file_path):
             self.__detail = open(file_path, 'r', encoding='utf-8').read()

--- a/xmlParsing.py
+++ b/xmlParsing.py
@@ -29,7 +29,7 @@ class KCIPageParser:
     # expect the file to be named as @.xml#
     # where @ is the search string and # is the page number
     def fsearch(self):
-        i = 0
+        i = self.__basePage
         while True:
             if self.__searchMode == self.TITLE_MODE:
                 file_path = papery.CACHE_PREFIX + 'kci/title/' + self.__searchStr + '.xml' + str(i)
@@ -78,13 +78,13 @@ class KCIPageParser:
         
         for i, xml in enumerate(self.__pages):
             if self.__searchMode == self.TITLE_MODE:
-                path = papery.CACHE_PREFIX + 'kci/title/' + self.__searchStr + '.xml' + str(i)
+                path = papery.CACHE_PREFIX + 'kci/title/' + self.__searchStr + '.xml' + str(i + self.__basePage)
             elif self.__searchMode == self.AUTHOR_MODE:
-                path = papery.CACHE_PREFIX + 'kci/author/' + self.__searchStr + '.xml' + str(i)
+                path = papery.CACHE_PREFIX + 'kci/author/' + self.__searchStr + '.xml' + str(i + self.__basePage)
             elif self.__searchMode == self.JOURNAL_MODE:
-                path = papery.CACHE_PREFIX + 'kci/journal/' + self.__searchStr + '.xml' + str(i)
+                path = papery.CACHE_PREFIX + 'kci/journal/' + self.__searchStr + '.xml' + str(i + self.__basePage)
             elif self.__searchMode == self.INSTITUTION_MODE:
-                path = papery.CACHE_PREFIX + 'kci/institution/' + self.__searchStr + '.xml' + str(i)
+                path = papery.CACHE_PREFIX + 'kci/institution/' + self.__searchStr + '.xml' + str(i + self.__basePage)
             else:
                 raise ValueError('Invalid search mode')
 
@@ -216,7 +216,7 @@ class ScopusPageParser:
     # expect the file to be named as @.xml#
     # where @ is the search string and # is the page number
     def fsearch(self):
-        i = 0
+        i = self.__basePage
         while True:
             if self.__searchMode == self.TITLE_MODE:
                 file_path = papery.CACHE_PREFIX + 'scopus/title/' + self.__searchStr + '.xml' + str(i)
@@ -264,13 +264,13 @@ class ScopusPageParser:
         
         for i, xml in enumerate(self.__pages):
             if self.__searchMode == self.TITLE_MODE:
-                path = papery.CACHE_PREFIX + 'scopus/title/' + self.__searchStr + '.xml' + str(i)
+                path = papery.CACHE_PREFIX + 'scopus/title/' + self.__searchStr + '.xml' + str(i + self.__basePage)
             elif self.__searchMode == self.AUTHOR_MODE:
-                path = papery.CACHE_PREFIX + 'scopus/author/' + self.__searchStr + '.xml' + str(i)
+                path = papery.CACHE_PREFIX + 'scopus/author/' + self.__searchStr + '.xml' + str(i + self.__basePage)
             elif self.__searchMode == self.JOURNAL_MODE:
-                path = papery.CACHE_PREFIX + 'scopus/journal/' + self.__searchStr + '.xml' + str(i)
+                path = papery.CACHE_PREFIX + 'scopus/journal/' + self.__searchStr + '.xml' + str(i + self.__basePage)
             elif self.__searchMode == self.INSTITUTION_MODE:
-                path = papery.CACHE_PREFIX + 'scopus/institution/' + self.__searchStr + '.xml' + str(i)
+                path = papery.CACHE_PREFIX + 'scopus/institution/' + self.__searchStr + '.xml' + str(i + self.__basePage)
             else:
                 raise ValueError('Invalid search mode')
             

--- a/xmlParsing.py
+++ b/xmlParsing.py
@@ -6,7 +6,7 @@ import os
 
 class PageParser:
     KCI = 'KCI'
-    GOOGLE_SCHOLAR = 'Google Scholar'
+    SCOPUS = 'Scopus'
     TITLE_MODE = 0
     AUTHOR_MODE = 1
     JOURNAL_MODE = 2
@@ -56,14 +56,14 @@ class PageParser:
 
         return self.__pages
     
-    def __isearchGoogleScholar(self, willCache=True):
+    def __isearchScopus(self, willCache=True):
         pass
 
     def isearch(self, willCache=True):
         if self.__source == self.KCI:
             return self.__isearchKCI(willCache)
-        elif self.__source == self.GOOGLE_SCHOLAR:
-            return self.__isearchGoogleScholar(willCache)
+        elif self.__source == self.SCOPUS:
+            return self.__isearchScopus(willCache)
         raise ValueError('Invalid source')
 
     # short for file search
@@ -212,7 +212,7 @@ class PageParseResult:
 
 class DetailParser:
     KCI = 'KCI'
-    GOOGLE_SCHOLAR = 'Google Scholar'
+    SCOPUS = 'Scopus'
 
     def __init__(self, articleID, source=KCI):
         self.__key = papery.KEY
@@ -236,14 +236,14 @@ class DetailParser:
 
         return self.__detail
     
-    def __isearchGoogleScholar(self, willCache=True):
+    def __isearchScopus(self, willCache=True):
         pass
 
     def isearch(self, willCache=True):
         if self.__source == self.KCI:
             return self.__isearchKCI(willCache)
-        elif self.__source == self.GOOGLE_SCHOLAR:
-            return self.__isearchGoogleScholar(willCache)
+        elif self.__source == self.SCOPUS:
+            return self.__isearchScopus(willCache)
         raise ValueError('Invalid source')
     
     # short for file search

--- a/xmlParsing.py
+++ b/xmlParsing.py
@@ -121,18 +121,20 @@ class KCIPageParser:
                 arti = item.find('articleInfo')
 
                 self.results.append( KCIPageParseResult(
-                    self.__getArticleID(arti),
-                    self.__getTitle(arti),
-                    self.__getAuthorNames(arti),
-                    self.__getPubYear(jour),
-                    self.__getAbstract(arti),
-                    self.__getJournal(jour),
-                    self.__getInstitution(jour),
-                    self.__getVolume(jour),
-                    self.__getIssue(jour),
-                    self.__getDOI(arti),
-                    self.__getURL(arti),
-                    self.__getCitationCount(arti)
+                    articleID=self.__getArticleID(arti),
+                    title=self.__getTitle(arti),
+                    authors=self.__getAuthorNames(arti),
+                    year=self.__getPubYear(jour),
+                    abstract=self.__getAbstract(arti),
+                    journal=self.__getJournal(jour),
+                    institution=self.__getInstitution(jour),
+                    volume=self.__getVolume(jour),
+                    issue=self.__getIssue(jour),
+                    fPage=self.__getFPage(arti),
+                    lPage=self.__getLPage(arti),
+                    doi=self.__getDOI(arti),
+                    url=self.__getURL(arti),
+                    citationCnt=self.__getCitationCount(arti)
                 ) )
 
         return self.results
@@ -187,6 +189,12 @@ class KCIPageParser:
     
     def __getInstitution(self, item):
         return self.__getItem(item, 'publisher-name')
+    
+    def __getFPage(self, item):
+        return self.__getItem(item, 'fpage')
+    
+    def __getLPage(self, item):
+        return self.__getItem(item, 'lpage')
     
 class ScopusPageParser:
     TITLE_MODE = 0
@@ -300,8 +308,9 @@ class ScopusPageParser:
                     institution=self.__getInstitution(item),
                     volume=self.__getVolume(item),
                     issue=self.__getIssue(item),
+                    fPage=self.__getFPage(item),
+                    lPage=self.__getLPage(item),
                     doi=self.__getDOI(item),
-                    url=None,
                     citationCnt=self.__getCitationCount(item)
                 ) )
 
@@ -359,6 +368,20 @@ class ScopusPageParser:
     
     def __getCitationCount(self, entry):
         return self.__getItem(entry, 'atom:citedby-count')
+    
+    def __getFPage(self, entry):
+        pr = self.__getItem(entry, 'prism:pageRange')
+        if pr is not None:
+            return pr.split('-')[0]
+        
+        return None
+    
+    def __getLPage(self, entry):
+        pr = self.__getItem(entry, 'prism:pageRange')
+        if pr is not None:
+            return pr.split('-')[1]
+        
+        return None
     
 
 class PageParser:
@@ -435,7 +458,8 @@ class PageParser:
 class KCIPageParseResult:
     def __init__(self, articleID, title, authors,
         year, abstract ,journal, institution,
-        volume, issue, doi, url, citationCnt
+        volume, issue, fPage, lPage, doi, url,
+        citationCnt
     ):
         self.articleID = articleID
         self.title = title
@@ -449,6 +473,8 @@ class KCIPageParseResult:
         self.doi = doi
         self.url = url
         self.citationCnt = citationCnt
+        self.fPage = fPage
+        self.lPage = lPage
 
     def reflect(self, paper):
         paper.title = self.title
@@ -459,6 +485,8 @@ class KCIPageParseResult:
         paper.institution = self.institution
         paper.volume = self.volume
         paper.issue = self.issue
+        paper.fPage = self.fPage
+        paper.lPage = self.lPage
         paper.doi = self.doi
         paper.url = self.url
         paper.citationCnt = self.citationCnt
@@ -466,8 +494,8 @@ class KCIPageParseResult:
 
 class ScopusPageParseResult:
     def __init__(self, articleID, title, authors,
-        year, journal, institution,
-        volume, issue, doi, citationCnt
+        year, journal, institution, volume, issue,
+        fPage, lPage, doi, citationCnt
     ):
         self.articleID = articleID
         self.title = title
@@ -477,6 +505,8 @@ class ScopusPageParseResult:
         self.institution = institution
         self.volume = volume
         self.issue = issue
+        self.fPage = fPage
+        self.lPage = lPage
         self.doi = doi
         self.citationCnt = citationCnt
 
@@ -488,6 +518,8 @@ class ScopusPageParseResult:
         paper.institution = self.institution
         paper.volume = self.volume
         paper.issue = self.issue
+        paper.fPage = self.fPage
+        paper.lPage = self.lPage
         paper.doi = self.doi
         paper.citationCnt = self.citationCnt
         paper.articleID = self.articleID
@@ -767,4 +799,4 @@ if __name__ == '__main__':
     # print('references:', r.refs)
     # print('author institutions:', r.authorInsts)
 
-    r = ScopusDetailParser('2-s2.0-85192867679').isearch()
+    r = ScopusPageParser('deep learning', ScopusPageParser.TITLE_MODE, 1, 60).searchAndParse()

--- a/xmlParsing.py
+++ b/xmlParsing.py
@@ -120,7 +120,7 @@ class KCIPageParser:
                 jour = item.find('journalInfo')
                 arti = item.find('articleInfo')
 
-                self.results.append( PageParseResult(
+                self.results.append( KCIPageParseResult(
                     self.__getArticleID(arti),
                     self.__getTitle(arti),
                     self.__getAuthorNames(arti),
@@ -291,20 +291,17 @@ class ScopusPageParser:
             root = ET.fromstring(page)
 
             for item in root.findall('atom:entry', ScopusPageParser.XML_NAMESPACES):
-                self.results.append( PageParseResult(
+                self.results.append( ScopusPageParseResult(
                     articleID=self.__getArticleID(item),
                     title=self.__getTitle(item),
                     authors=self.__getAuthorNames(item),
                     year=self.__getPubYear(item),
-                    abstract=None,
-                    # self.__getAbstract(item),
                     journal=self.__getJournal(item),
                     institution=self.__getInstitution(item),
                     volume=self.__getVolume(item),
                     issue=self.__getIssue(item),
                     doi=self.__getDOI(item),
                     url=None,
-                    # self.__getURL(item),
                     citationCnt=self.__getCitationCount(item)
                 ) )
 
@@ -435,7 +432,7 @@ class PageParser:
             return None
         raise ValueError('Invalid source')
     
-class PageParseResult:
+class KCIPageParseResult:
     def __init__(self, articleID, title, authors,
         year, abstract ,journal, institution,
         volume, issue, doi, url, citationCnt
@@ -464,6 +461,34 @@ class PageParseResult:
         paper.issue = self.issue
         paper.doi = self.doi
         paper.url = self.url
+        paper.citationCnt = self.citationCnt
+        paper.articleID = self.articleID
+
+class ScopusPageParseResult:
+    def __init__(self, articleID, title, authors,
+        year, journal, institution,
+        volume, issue, doi, citationCnt
+    ):
+        self.articleID = articleID
+        self.title = title
+        self.authors = authors
+        self.year = year
+        self.journal = journal
+        self.institution = institution
+        self.volume = volume
+        self.issue = issue
+        self.doi = doi
+        self.citationCnt = citationCnt
+
+    def reflect(self, paper):
+        paper.title = self.title
+        paper.authors = self.authors
+        paper.year = self.year
+        paper.journal = self.journal
+        paper.institution = self.institution
+        paper.volume = self.volume
+        paper.issue = self.issue
+        paper.doi = self.doi
         paper.citationCnt = self.citationCnt
         paper.articleID = self.articleID
 
@@ -521,7 +546,7 @@ class KCIDetailParser:
             keywords.extend( self.__getKeywords(arti) )
             authorInsts.extend( self.__getAuthorInsts(arti) )
 
-        return DetailParseResult(keywords, refs, authorInsts)
+        return KCIDetailParseResult(keywords, refs, authorInsts)
 
     def isearchAndParse(self, willCache=True):
         self.isearch(willCache)
@@ -624,13 +649,26 @@ class DetailParser:
             return None
         raise ValueError('Invalid source')
     
-class DetailParseResult:
+class KCIDetailParseResult:
     def __init__(self, keywords, refs, authorInsts):
         self.keywords = keywords
         self.refs = refs
         self.authorInsts = authorInsts
 
     def reflect(self, paper):
+        paper.keywords = self.keywords
+        paper.refs = self.refs
+        paper.authorInsts = self.authorInsts
+
+class ScopusDetailParseResult:
+    def __init__(self, abstract, keywords, refs, authorInsts):
+        self.abstract = abstract
+        self.keywords = keywords
+        self.refs = refs
+        self.authorInsts = authorInsts
+
+    def reflect(self, paper):
+        paper.abstract = self.abstract
         paper.keywords = self.keywords
         paper.refs = self.refs
         paper.authorInsts = self.authorInsts


### PR DESCRIPTION
## Bug Fix
- 불러올 다음 페이지가 없어도 페이지가 넘어가지는 버그 수정
  - 불러올 페이지 없을 시 '마지막 페이지입니다.' 메시지 박스 출력
- 보드에 나타나는 페이지 수가 10개 미만일 때 버튼 수가 1개 부족한 버그 수정
- 캐시 인덱싱이 항상 0~2로 고정되던 버그 수정
- 새롭게 검색을 하여도 선택된 페이지가 1페이지로 초기화되지 않던 버그 수정
- 한 페이지의 레코드 수가 10개 미만일 때 의미 없는 예외가 발생하던 버그 수정

## 구현된 기능
- Scopus 검색 및 파싱
- 다양한 검색 설정
  - 제목 검색, 저자 검색, 학술지 검색, 기관 검색
- 비동기 검색
  - 검색이 진행되는 동안 페이지 버튼이나 뷰 버튼 등은 비활성화되고,
    gif 애니메이션이 진행되는 로딩창이 뜸

## 미구현 기능
- Scopus Detail 검색 (학교에서 기관 구독 인증해야함)
- gui에 Scopus 검색 설정 반영

## Note
- 환경변수의 변경이 있음 (KCI용 key와 Scopus용 key 분리)
  - `KCI_KEY = os.environ['PAPER_API_KCI_KEY']`
  - `SCOPUS_KEY = os.environ['PAPER_API_SCOPUS_KEY']`
- cache 디렉터리 설정이 필요함
  - #15 참고 